### PR TITLE
Update inputmask version from 5.0.5 to 5.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4654,9 +4654,9 @@
       "dev": true
     },
     "inputmask": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.5.tgz",
-      "integrity": "sha512-9gqau4tb0oaxYiymLC43KU/aAXHVofya7ilGIxqKONbSh7LNKRHmpw6mhuH2D4yykRlcNhS9zI/FOsrAQmltQA=="
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.7.tgz",
+      "integrity": "sha512-rUxbRDS25KEib+c/Ow+K01oprU/+EK9t9SOPC8ov94/ftULGDqj1zOgRU/Hko6uzoKRMdwCfuhAafJ/Wk2wffQ=="
     },
     "inquirer": {
       "version": "8.2.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser-dynamic": "^14.2.0",
     "@angular/router": "^14.2.0",
     "@ngneat/input-mask": "^5.2.0",
-    "inputmask": "5.0.5",
+    "inputmask": "5.0.7",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"


### PR DESCRIPTION
- Problema:
O campo do número da tarefa não estava reconhecendo o valor quando o mesmo era colado. Isso ocorreu a um problema existente no pacote input-mask.
- Solução:
Foi atualizado para a versão mais recente do pacote input-mask que já possui uma correção para esse bug.